### PR TITLE
Fix lis matrix get max diag coeff

### DIFF
--- a/MathLib/LinAlg/Lis/LisVector.cpp
+++ b/MathLib/LinAlg/Lis/LisVector.cpp
@@ -13,19 +13,18 @@
  */
 
 #include "LisVector.h"
+#include "LisCheck.h"
 
 namespace MathLib
 {
 
 LisVector::LisVector(std::size_t length)
-: _length(length)
 {
     lis_vector_create(0, &_vec);
     lis_vector_set_size(_vec, 0, length);
 }
 
 LisVector::LisVector(LisVector const &src)
-: _length(src.size())
 {
 	lis_vector_duplicate(src._vec, &_vec);
 	lis_vector_copy(src._vec, _vec);
@@ -56,6 +55,15 @@ LisVector& LisVector::operator= (double v)
 {
     lis_vector_set_all(v, _vec);
     return *this;
+}
+
+std::size_t LisVector::size() const
+{
+	LIS_INT dummy;
+	LIS_INT size;
+	int const ierr = lis_vector_get_size(_vec, &dummy, &size);
+	checkLisError(ierr);
+	return size;
 }
 
 void LisVector::write (const std::string &filename) const

--- a/MathLib/LinAlg/Lis/LisVector.h
+++ b/MathLib/LinAlg/Lis/LisVector.h
@@ -45,13 +45,13 @@ public:
     virtual ~LisVector();
 
     /// return a vector length
-    std::size_t size() const {return _length;};
+    std::size_t size() const;
 
     /// return a start index of the active data range
     std::size_t getRangeBegin() const { return 0;}
 
     /// return an end index of the active data range
-    std::size_t getRangeEnd() const { return _length; }
+    std::size_t getRangeEnd() const { return this->size(); }
 
     /// set all values in this vector
     LisVector& operator= (double v);
@@ -103,7 +103,6 @@ public:
         }
     }
 private:
-    std::size_t const _length;
     LIS_VECTOR _vec;
 };
 


### PR DESCRIPTION
Move code parts to their owners. Split up methods. Extent `getMaxDiagCoeff()` to already assembled matrices.
